### PR TITLE
Update Angular 2 to latest official release beta.9

### DIFF
--- a/systemjs/gulpfile.js
+++ b/systemjs/gulpfile.js
@@ -14,7 +14,7 @@ gulp.task('ts2js', function () {
     var tscConfig = require('./tsconfig.json');
 
     var tsResult = gulp
-        .src(PATHS.src)
+        .src([PATHS.src, 'node_modules/angular2/typings/browser.d.ts'])
         .pipe(typescript(tscConfig.compilerOptions));
 
     return tsResult.js.pipe(gulp.dest('dist'));

--- a/systemjs/index.html
+++ b/systemjs/index.html
@@ -32,8 +32,8 @@
 </script>
 <script src="/node_modules/rxjs/bundles/Rx.js"></script>
 <script src="/node_modules/angular2/bundles/angular2.js"></script>
-<script src="/node_modules/angular2/bundles/http.min.js"></script>
-<script src="/node_modules/angular2/bundles/router.min.js"></script>
+<script src="/node_modules/angular2/bundles/http.js"></script>
+<script src="/node_modules/angular2/bundles/router.js"></script>
 <script>
     //bootstrap the Angular2 application
     System.import('dist/app').catch(console.log.bind(console));

--- a/systemjs/package.json
+++ b/systemjs/package.json
@@ -18,12 +18,12 @@
     "serve-static": "^1.10.0"
   },
   "dependencies": {
-    "angular2": "2.0.0-beta.2",
+    "angular2": "2.0.0-beta.9",
     "es6-promise": "^3.0.2",
     "es6-shim": "^0.33.3",
     "reflect-metadata": "0.1.2",
-    "rxjs": "5.0.0-beta.0",
-    "zone.js": "0.5.10",
+    "rxjs": "5.0.0-beta.2",
+    "zone.js": "0.5.15",
     "systemjs": "0.19.6",
     "angular2-jwt": "0.1.6"
   }

--- a/webpack/package.json
+++ b/webpack/package.json
@@ -32,13 +32,14 @@
     "postinstall": "typings install"
   },
   "dependencies": {
-    "angular2": "2.0.0-beta.1",
+    "angular2": "2.0.0-beta.9",
     "core-js": "^1.2.6",
-    "reflect-metadata": "0.1.2",
-    "rxjs": "5.0.0-beta.0",
-    "zone.js": "0.5.10",
+    "rxjs": "5.0.0-beta.2",
+    "zone.js": "0.5.15",
     "angular2-jwt": "0.1.6",
-    "es6-shim": "^0.33.3"
+    "es6-promise" : "^3.1.2",
+    "es6-shim": "^0.33.3",
+    "es7-reflect-metadata" : "^1.6.0"
   },
   "devDependencies": {
     "css-loader": "^0.23.0",
@@ -62,13 +63,13 @@
     "style-loader": "^0.13.0",
     "ts-loader": "^0.7.2",
     "tsconfig-lint": "^0.2.0",
-    "tslint": "^3.2.0",
-    "tslint-loader": "^2.1.0",
+    "tslint": "^3.5.0",
+    "tslint-loader": "^2.1.3",
     "typedoc": "^0.3.12",
-    "typescript": "^1.7.3",
-    "typings": "^0.3.1",
-    "url-loader": "^0.5.6",
-    "webpack": "^1.12.9",
-    "webpack-dev-server": "^1.12.1"
+    "typescript": "^1.8.7",
+    "typings": "^0.6.8",
+    "url-loader": "^0.5.7",
+    "webpack": "^1.12.14",
+    "webpack-dev-server": "^1.14.1"
   }
 }

--- a/webpack/typings.json
+++ b/webpack/typings.json
@@ -1,15 +1,16 @@
 {
   "dependencies": {
-    "es6-promise": "github:typings/typed-es6-promise#9243c53f70fb4909ed7cce3094bec221b9fb6d5f"
+    "es6-promise": "github:typed-typings/npm-es6-promise#fb04188767acfec1defd054fc8024fafa5cd4de7"
   },
   "devDependencies": {},
   "ambientDependencies": {
-    "angular-protractor": "github:angular/DefinitelyTyped/angular-protractor/angular-protractor.d.ts#31e7317c9a0793857109236ef7c7f223305a8aa9",
-    "es6-shim": "github:angular/DefinitelyTyped/es6-shim/es6-shim.d.ts#31e7317c9a0793857109236ef7c7f223305a8aa9",
-    "hammerjs": "github:angular/DefinitelyTyped/hammerjs/hammerjs.d.ts#31e7317c9a0793857109236ef7c7f223305a8aa9",
-    "jasmine": "github:angular/DefinitelyTyped/jasmine/jasmine.d.ts#31e7317c9a0793857109236ef7c7f223305a8aa9",
-    "node": "github:angular/DefinitelyTyped/node/node.d.ts#31e7317c9a0793857109236ef7c7f223305a8aa9",
-    "selenium-webdriver": "github:angular/DefinitelyTyped/selenium-webdriver/selenium-webdriver.d.ts#31e7317c9a0793857109236ef7c7f223305a8aa9",
-    "zone": "github:angular/DefinitelyTyped/zone/zone.d.ts#31e7317c9a0793857109236ef7c7f223305a8aa9"
+    "angular-protractor": "github:DefinitelyTyped/DefinitelyTyped/angular-protractor/angular-protractor.d.ts#64b25f63f0ec821040a5d3e049a976865062ed9d",
+    "es6-shim": "github:DefinitelyTyped/DefinitelyTyped/es6-shim/es6-shim.d.ts#6697d6f7dadbf5773cb40ecda35a76027e0783b2",
+    "hammerjs": "github:DefinitelyTyped/DefinitelyTyped/hammerjs/hammerjs.d.ts#74a4dfc1bc2dfadec47b8aae953b28546cb9c6b7",
+    "jasmine": "github:DefinitelyTyped/DefinitelyTyped/jasmine/jasmine.d.ts#4b36b94d5910aa8a4d20bdcd5bd1f9ae6ad18d3c",
+    "node": "github:DefinitelyTyped/DefinitelyTyped/node/node.d.ts#8cf8164641be73e8f1e652c2a5b967c7210b6729",
+    "selenium-webdriver": "github:DefinitelyTyped/DefinitelyTyped/selenium-webdriver/selenium-webdriver.d.ts#a83677ed13add14c2ab06c7325d182d0ba2784ea",
+    "webpack": "github:DefinitelyTyped/DefinitelyTyped/webpack/webpack.d.ts#95c02169ba8fa58ac1092422efbd2e3174a206f4",
+    "zone.js": "github:DefinitelyTyped/DefinitelyTyped/zone.js/zone.js.d.ts#c393f8974d44840a6c9cc6d5b5c0188a8f05143d"
   }
 }


### PR DESCRIPTION
Update Angular 2 to latest release and accompanying dependencies.

For systemjs demo had to switch back to using non-minified libraries for now as the .min ones are broken.
